### PR TITLE
changes jetson wheelchair base (working!!)

### DIFF
--- a/docs/jetson.md
+++ b/docs/jetson.md
@@ -1,0 +1,4 @@
+## testing humble and base image for jetson
+
+- rn The wheelchair_base_jetson image works with the harware, but i dont have the Dockerfile for it, So I am testing which configuration it is in it 
+it doesnt work with the dusky guys base image

--- a/wheelchair2_base_jetson/Dockerfile
+++ b/wheelchair2_base_jetson/Dockerfile
@@ -1,4 +1,4 @@
-FROM dustynv/ros:humble-desktop-l4t-r36.4.0
+FROM ghcr.io/smart-wheelchair-rrc/humble_jetson:v1.0
 
 # Add the following labels
 LABEL org.opencontainers.image.description="Wheelchair2-Jetson"
@@ -10,8 +10,7 @@ LABEL org.opencontainers.image.licenses="MIT"
 # handle default shell
 SHELL ["/bin/bash", "-c"]
 
-# Install Basic deps
-# COPY rosPkgs.list /tmp/rosPkgs.list$(cat /tmp/rosPkgs.list)
+
 RUN sudo apt-get update \
     && sudo apt-get -y install --no-install-recommends  \
     libssl-dev \
@@ -51,3 +50,8 @@ RUN sudo mkdir -p /etc/udev/rules.d && \
 RUN mkdir build && cd build \
     && cmake ../ \
     && sudo make uninstall && make clean && make && sudo make install 
+
+COPY rosPkgs.list /tmp/rosPkgs.list
+RUN sudo apt-get update \
+    && sudo apt-get -y install --no-install-recommends $(cat /tmp/rosPkgs.list) \
+    && sudo rm -rf /var/lib/apt/lists/*

--- a/wheelchair2_base_jetson/rosPkgs.list
+++ b/wheelchair2_base_jetson/rosPkgs.list
@@ -6,3 +6,4 @@ ros-humble-nav2-bringup
 ros-humble-navigation2
 ros-humble-spatio-temporal-voxel-layer
 ros-humble-hardware-interface
+ros-humble-pcl-ros


### PR DESCRIPTION
The docker file in wheelchair_base_jetson was pulling the wrong humble image. Now its fixed and the humble image is also pushed to ghcr