### PR TITLE
wheelchair run commands update 

### DIFF
--- a/ROS1/README.md
+++ b/ROS1/README.md
@@ -45,6 +45,11 @@
 docker run -it --rm --privileged --gpus=all --cap-add=SYS_NICE --ulimit rtprio=99 --ulimit rttime=-1 --ulimit memlock=8428281856 --cap-add=all --security-opt seccomp:unconfined --security-opt apparmor:unconfined --volume=/dev:/dev --net=host --ipc=host -e DISPLAY="${DISPLAY}" -e WAYLAND_DISPLAY="${WAYLAND_DISPLAY}" -e XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR}" -e PULSE_SERVER="${PULSE_SERVER}" -e QT_X11_NO_MITSHM="1" -e LIBGL_ALWAYS_SOFTWARE="1" --device /dev/ttyUSB0:/dev/ttyUSB0 --entrypoint /bin/bash --name wheelchair_cs wheelchair1_crowdsurfer
 ```
 
+### To open multiple terminals with the above container use
+```
+docker exec -it wheelchair_cs bash
+```
+
 ### Running the wheelchair
 
 ```


### PR DESCRIPTION
Added the commands in https://github.com/Smart-Wheelchair-RRC/DockerForDevelopment/pull/11/commits/153adaa3ac1aebeef18a46b230e94a50a3eec14b needed to run the wheelchair using docker and ROS1 with crowdsurfer. Later we may forget the commands so I thought we should have it in the README file.