### PR TITLE
turtlebot2 noetic package update for Dockerfile

### DIFF
--- a/ROS1/x86/wheelchair1_base/Dockerfile
+++ b/ROS1/x86/wheelchair1_base/Dockerfile
@@ -36,6 +36,7 @@ RUN wget https://raw.githubusercontent.com/zzuxzt/turtlebot2_noetic_packages/mas
     && sudo apt-get install ros-noetic-joy
     && sudo apt-get install ros-noetic-kobuki-driver
     && python -m pip install defusedxml
+    && rm -rf turtlebot2_noetic_install.sh
 
 # Realsense SDK
 RUN git clone https://github.com/IntelRealSense/librealsense.git \


### PR DESCRIPTION
I have run the 2 docker run commands in the container for setting up turtlebot2 noetic package for crowdsurfer. I am attaching the ss below

![image](https://github.com/user-attachments/assets/d345761f-5188-4003-a21a-aa0bf388af32)
